### PR TITLE
Refactor commands due to grammatical incongruence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ To use the console, simply type.
 
 - `import` - Import existing log data
 - `export` - Export log data
-- `start "Sector" "Project" "Description"` - Start a log entry
-- `end` - End a log entry
+- `start "Sector" "Project" "Description"` - Start a log entry (alt: `begin`)
+- `stop` - Stop a log entry (alt: `end`)
 - `pause` - Pause a log session
-- `continue/resume` - Continue the last log session
+- `continue` - Continue the last log session (alt: `resume`)
 - `edit {ID} {attribute} "Lorem ipsum"` - Edit an entry's attributes
 - `set bg #fff` - Set the interface's background colour
 - `set colour red` - Set the interface's text colour

--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
     <div class="nodrag mb5 mb0-l c6 pr4-l hf-l oya-l">
       <h2 class="mb3 f5">Guide</h2>
 
-      <p class="mb4">The Log is designed for single-tasking. When you start a log, focus on your activity and end the log whenever you feel like stopping.</p>
+      <p class="mb4">The Log is designed for single-tasking. When you start a log, focus on your activity and stop at any time.</p>
 
       <h3 class="mb3 f5">Console</h3>
       <p class="mb4 m">Use the console to enter commands. The console is summoned when you start typing. Here are a list of available commands:</p>
@@ -488,18 +488,18 @@
 
       <p class="mb4 m">A <b>Sector</b> defines an activity type. A <b>Project</b> can involve one or more Sectors. For example, let's say you're working on an app project. This project may involve Design, Code, and Research sectors.</p>
 
-      <p class="mb3 m">To end a log:</p>
+      <p class="mb3 m">To stop logging:</p>
       <div class="mb4 bl pl3 m">
-        <p>end</p>
+        <p>stop</p>
       </div>
 
-      <p class="mb3 m">If you want to take a break, temporarily end a log, and resume later:</p>
+      <p class="mb3 m">If you want pause logging temporarily, and resume logging from where you left off previously:</p>
       <div class="mb4 bl pl3 m">
-        <p>pause <span class="o8">// ends your log session</span></p>
+        <p>pause <span class="o8">// stops your current log session</span></p>
         <p>resume <span class="o8">// resumes the last log session</span></p>
       </div>
 
-      <p class="mb3 m">To edit an entry, use its ID (shown in Entries):</p>
+      <p class="mb3 m">To edit a log entry, use its ID (shown in Entries):</p>
       <div class="mb4 bl pl3 m">
         <p class="mb2">edit 12 sector "Code" <span class="o8">// edits entry #12</span></p>
         <p class="mb2">edit 25 project "Fishing"</p>
@@ -509,7 +509,7 @@
         <p>edit 5 end "2018 10 9 12 15 0"</p>
       </div>
 
-      <p class="mb3 m">To delete an entry, use its ID:</p>
+      <p class="mb3 m">To delete a log entry, use its ID:</p>
       <div class="mb4 bl pl3 m">
         <p>delete 15 <span class="o8">// deletes entry #15</span></p>
       </div>

--- a/js/console.js
+++ b/js/console.js
@@ -2,56 +2,47 @@ Log = window.Log || {}
 Log.console = {
   history: [],
 
-  commands: [
-    'start', 'end', 'delete', 'set', 'import', 'export', 'invert', 'edit', 'pause', 'continue', 'resume', 'rename'
-  ],
-
   /**
    * Parse command
    * @param {string} i - Input
    */
   parse(i) {
-    let k = Log.console.commands.indexOf(i.split(' ')[0].toLowerCase())
 
-    if (k === -1) return
+    let command = i.split(' ')[0].toLowerCase()
 
-    switch (k) {
-      case 0:
+    switch (command) {
+      case 'start': case 'begin':
         Log.console.startLog(i);
         break;
-      case 1:
+      case 'stop': case 'end': case 'pause':
         Log.console.endLog();
         break;
-      case 2:
-        Log.console.delete(i);
+      case 'resume': case 'continue':
+        Log.console.resume();
         break;
-      case 3:
-        Log.console.set(i);
-        break;
-      case 4:
-        Log.console.importUser();
-        break;
-      case 5:
-        Log.console.exportUser();
-        break;
-      case 6:
-        Log.console.invert();
-        break;
-      case 7:
+      case 'edit':
         Log.console.edit(i);
         break;
-      case 8:
-        Log.console.endLog();
+      case 'delete':
+        Log.console.delete(i);
         break;
-      case 9:
-        Log.console.resume();
+      case 'set':
+        Log.console.set(i);
         break;
-      case 10:
-        Log.console.resume();
+      case 'import':
+        Log.console.importUser();
         break;
-      case 11:
+      case 'export':
+        Log.console.exportUser();
+        break;
+      case 'rename':
         Log.console.rename(i);
         break;
+      case 'invert':
+        Log.console.invert();
+        break;
+      default:
+        return
     }
   },
 


### PR DESCRIPTION
Hi Josh,

Log is a cool little program! I'm using it right as I type this. Unfortunately to me there is one glaring annoyance: `start` and `end` are not complimentary antonyms of one another! In English, we pair 'Start' with 'Stop', and 'Begin' (or 'Beginning') with 'End'.

In this PR I have refactored the code and documentation so that `end` is swapped for `stop` as the default, maintaining the existing functionality of `end`.

I have also made the parsing of the commands simpler and more sensible. There is no performance advantage in using `indexOf(x)` as it will have to do an iterative comparison on the array provided. Therefore, it is better to just leverage the switch statement to have clearer string command cases and merge cases which produce equivalent actions.