### PR TITLE
Console command: edit <id> duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,8 @@
         <p class="mb2">edit 3 description "Chasing dragon"</p>
         <p class="mb2">edit 24 start "YYYY MM DD HH MM SS"</p>
         <p class="mb2">edit 1 start "2017 12 15 13 30 14"</p>
-        <p>edit 5 end "2018 10 9 12 15 0"</p>
+        <p class="mb2">edit 5 end "2018 10 9 12 15 0"</p>
+        <p>edit 4 duration "90" <span class="o8">// sets duration in minutes</span></p>
       </div>
 
       <p class="mb3 m">To delete a log entry, use its ID:</p>

--- a/js/console.js
+++ b/js/console.js
@@ -280,7 +280,10 @@ Log.console = {
       user.log[id].s = Log.time.convertDateTime(proc(i))
     else if (contains(a, 'end'))
       user.log[id].e = Log.time.convertDateTime(proc(i))
-    else return
+    else if (contains('duration dur')) {
+      let duration = parseInt(proc(i), 10) * 60 || 0
+      user.log[id].e = Log.time.offset(user.log[id].s, duration)
+    } else return
 
     Log.options.update()
   },

--- a/js/time.js
+++ b/js/time.js
@@ -145,5 +145,15 @@ Log.time = {
    */
   duration(a, b) {
     return (Log.time.parse(b) - Log.time.parse(a)) / 3600
+  },
+
+  /**
+   * Returns a timestamp `duration` seconds after `start`
+   * @param {string} start - hexadecimal timestamp
+   * @param {number} duration - length to offset by (seconds)
+   * @returns {string} end - hexadecimal timestamp
+   */
+  offset(start, duration) {
+    return (Log.time.parse(start) + duration).toString(16)
   }
 }


### PR DESCRIPTION
Allows the user to change the duration of an entry instead of specifying the end time manually — useful as a shorthand in place of typing out the full date/time.

Thanks! :)