### PR TITLE
Use idiomatic icon reference

### DIFF
--- a/log.desktop
+++ b/log.desktop
@@ -6,6 +6,6 @@ Name=Log
 Comment=Log and time-tracking utility
 Path=/usr/bin
 Exec=log
-Icon=icon.png
+Icon=log
 Terminal=false
 Categories=Productivity;


### PR DESCRIPTION
This allows placing the icon in e.g. `/usr/share/icons/hicolor/apps/log.png`.
I'm no expert, but all other desktop entries I checked did it this way, and there were no icons in the same folder as the `.desktop`-files, so didn't want to start doing weird symlinks and stuff when packaging :)