### PR TITLE
Add common macOS shortcuts

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,8 @@
 const {
   app,
   BrowserWindow,
-  webFrame
+  webFrame,
+  Menu
 } = require('electron');
 
 if (process.argv[2] && process.argv[2] === 'dev') {
@@ -26,6 +27,26 @@ app.on('ready', _ => {
   win.on('closed', _ => {
     win = null
   })
+
+  if (process.platform === 'darwin') {
+    var menu = Menu.buildFromTemplate([
+      {
+        label: app.getName(),
+        submenu: [
+          {role: 'about'},
+          {type: 'separator'},
+          {role: 'minimize'},
+          {role: 'hide'},
+          {role: 'hideothers'},
+          {role: 'unhide'},
+          {type: 'separator'},
+          {role: 'quit'}
+        ]
+      }
+    ]);
+
+    Menu.setApplicationMenu(menu);
+  }
 })
 
 app.on('window-all-closed', _ => {


### PR DESCRIPTION
I’ve never built or modified an electron app before, but I noticed the lack of window shortcuts, saw the issue (#14), and then looked up the documentation to do this. I have no clue if this is where you would set the menu. Let me know if anything needs to change. I put everything in the main Log menu for the sake of simplicity.

<img width="397" alt="log-menu-shortcuts" src="https://user-images.githubusercontent.com/6908001/40026297-03b9171c-5792-11e8-97f4-82db8a558808.png">
