### PR TITLE
Use Log.displayStat to the entry times in the journal detail view

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -100,7 +100,7 @@ Log.journal = {
       time.innerHTML = `${Log.time.stamp(Log.time.toEpoch(ent[i].s))} &ndash; ${Log.time.stamp(Log.time.toEpoch(ent[i].e))}`;
       sector.innerHTML = ent[i].c;
       project.innerHTML = ent[i].t;
-      duration.innerHTML = ent[i].dur.toFixed(2);
+      duration.innerHTML = Log.displayStat(ent[i].dur);
       desc.innerHTML = ent[i].d;
 
       item.appendChild(id);


### PR DESCRIPTION
Now, the stat configuration affects to the entry time in the journal detail view. This closes #60

**stat human**

<img width="1072" alt="screen shot 2018-06-29 at 10 39 08" src="https://user-images.githubusercontent.com/4056725/42082921-9a071866-7b89-11e8-8e46-488fdd298063.png">

**stat decimal**

<img width="1072" alt="screen shot 2018-06-29 at 10 39 28" src="https://user-images.githubusercontent.com/4056725/42082926-a071ba1c-7b89-11e8-9341-af4c2e0d768c.png">
